### PR TITLE
bump minimum linked_hashmap to 0.5.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ authors = ["nabijaczleweli <nabijaczleweli@gmail.com>"]
 
 
 [dependencies]
-linked-hash-map = "0.5"
+linked-hash-map = "0.5.3"
 lazysort = "0.2"
 jetscii = "0.4"
 


### PR DESCRIPTION
Linked_hashmap crate had an unsound issue in releases before 0.5.3. Bumping this as per the [advisory](https://github.com/RustSec/advisory-db/issues/298)